### PR TITLE
languages: Add C

### DIFF
--- a/src/languages.rs
+++ b/src/languages.rs
@@ -4,11 +4,13 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with cmark-syntax.  If not, see <http://www.gnu.org/licenses/>
+mod c;
 mod javascript;
 mod rust;
 mod sh;
 mod toml;
 
+pub use c::C;
 pub use javascript::JavaScript;
 pub use rust::Rust;
 pub use sh::Sh;

--- a/src/languages/c.rs
+++ b/src/languages/c.rs
@@ -1,0 +1,75 @@
+use crate::{Highlight, Kind};
+use logos::Logos;
+
+#[derive(Logos, PartialEq, Eq, Clone, Copy, Debug)]
+pub enum C {
+    #[regex("[a-zA-Z_$][a-zA-Z0-9_]*")]
+    Identifier,
+
+    #[regex("\"([^\"\\\\]|\\\\[.\n])*\"")]
+    #[regex("'([^']|\\\\')'")]
+    #[regex("[0-9][0-9]*")]
+    #[regex("0[xX][0-9a-fA-F]+")]
+    #[regex("0[bB][01]+")]
+    Literal,
+
+    #[regex(r#"\?|:|!|\^|-|\+|\*|&|/|<|>|="#, priority = 3)]
+    Glyph,
+
+    #[regex(r"\.|->")]
+    GlyphCtx,
+
+    #[regex("\\{|\\}|\\[|\\]|\\(|\\)")]
+    Bracket,
+
+    #[regex("asm|break|case|continue|default|defined|do|else|for|goto|if")]
+    #[regex("return|sizeof|static_assert|switch|typeof|typeof_unqual|while")]
+    #[regex("_Generic|_Noreturn")]
+    Keyword,
+
+    #[regex("#(define|elif|elifdef|elifndef|else|embed|endif|error|if|ifdef)")]
+    #[regex("#(ifndef|include|line|pragma|undef|warning)")]
+    Macro,
+
+    #[regex("enum|struct|typedef|union")]
+    KeywordCtx,
+
+    #[regex("auto|const|extern|inline|register|static|volatile")]
+    Qualifier,
+
+    #[regex("bool|char|complex|double|float|imaginary|long")]
+    #[regex("short|signed|unsigned|void")]
+    Type,
+
+    #[regex("false|NULL|nullptr|true")]
+    Constant,
+
+    #[regex("//[^\n]*")]
+    #[regex("/\\*([^/]|[^*]/)*\\*/")]
+    Comment,
+
+    None,
+}
+
+impl Highlight for C {
+    const LANG: &'static str = "c";
+    const START: Self = Self::None;
+
+    fn kind(tokens: &[Self; 2]) -> Kind {
+        use C::*;
+
+        match tokens {
+            [KeywordCtx, Identifier] | [GlyphCtx, Identifier] | [_, Type] => {
+                Kind::SpecialIdentifier
+            }
+            [_, Identifier] => Kind::Identifier,
+            [_, Literal] => Kind::Literal,
+            [_, Glyph] | [_, GlyphCtx] => Kind::Glyph,
+            [_, Keyword] | [_, KeywordCtx] | [_, Constant] | [_, Macro] | [_, Qualifier] => {
+                Kind::Keyword
+            }
+            [_, Comment] => Kind::Comment,
+            _ => Kind::None,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,7 @@ impl<'a, I: Iterator<Item = Event<'a>>> Iterator for SyntaxPreprocessor<'a, I> {
         html.push_str("\">");
 
         match lang.as_ref() {
+            "c" | "cpp" | "c++" => highlight::<languages::C>(&code, &mut html),
             "rust" | "rs" => highlight::<languages::Rust>(&code, &mut html),
             "js" | "javascript" => highlight::<languages::JavaScript>(&code, &mut html),
             "toml" => highlight::<languages::Toml>(&code, &mut html),


### PR DESCRIPTION
Adds simple C syntax highlighting mostly copied from the existing JS one, with some of the C23 stuff.

`#include`'s don't really work correctly but I'm unsure of if there's a way to contextually match `<.*>` as a literal.

I'm matching `cpp` as `c++` as a better-than-nothing solution for C++, even though this only highlights C.